### PR TITLE
Add tracking widget and check notifications

### DIFF
--- a/LeaseMilesTracker/Services/NotificationManager.swift
+++ b/LeaseMilesTracker/Services/NotificationManager.swift
@@ -96,4 +96,52 @@ class NotificationManager: ObservableObject {
             }
         }
     }
+    
+    func sendTestNotification() {
+        guard authorizationStatus == .authorized else { return }
+        
+        let content = UNMutableNotificationContent()
+        content.title = "Test Notification"
+        content.body = "This is a test notification from Lease Miles Tracker!"
+        content.sound = .default
+        
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(identifier: "test-notification", content: content, trigger: trigger)
+        
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                print("Error sending test notification: \(error)")
+            }
+        }
+    }
+    
+    func scheduleTestReminder(seconds: Int = 5) {
+        guard authorizationStatus == .authorized else { return }
+        
+        let content = UNMutableNotificationContent()
+        content.title = "Test Reminder"
+        content.body = "This is a test reminder scheduled \(seconds) seconds ago!"
+        content.sound = .default
+        
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: TimeInterval(seconds), repeats: false)
+        let request = UNNotificationRequest(identifier: "test-reminder", content: content, trigger: trigger)
+        
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                print("Error scheduling test reminder: \(error)")
+            }
+        }
+    }
+    
+    func cancelTestReminder() {
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ["test-reminder"])
+    }
+    
+    func getPendingNotifications() async -> [UNNotificationRequest] {
+        return await UNUserNotificationCenter.current().pendingNotificationRequests()
+    }
+    
+    func getDeliveredNotifications() async -> [UNNotification] {
+        return await UNUserNotificationCenter.current().deliveredNotifications()
+    }
 }

--- a/LeaseMilesTracker/Shared/SharedDataManager.swift
+++ b/LeaseMilesTracker/Shared/SharedDataManager.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SwiftData
+
+class SharedDataManager: ObservableObject {
+    static let shared = SharedDataManager()
+    
+    private let appGroupIdentifier = "group.com.leasemilestracker.shared"
+    private let userDefaults = UserDefaults(suiteName: "group.com.leasemilestracker.shared")
+    
+    private init() {}
+    
+    func updateWidgetData(settings: LeaseSettings, entries: [MileageEntry]) {
+        let snapshot = LeaseCalculator.calculateSnapshot(settings: settings, entries: entries)
+        
+        let widgetData = WidgetData(
+            milesDriven: snapshot.milesDriven,
+            remainingMiles: snapshot.remainingMiles,
+            monthsLeft: snapshot.monthsLeft,
+            projectedOverage: snapshot.projectedOverage,
+            lastUpdated: Date()
+        )
+        
+        if let data = try? JSONEncoder().encode(widgetData) {
+            userDefaults?.set(data, forKey: "widgetData")
+        }
+        
+        // Request widget timeline update
+        WidgetCenter.shared.reloadTimelines(ofKind: "LeaseMilesWidget")
+    }
+    
+    func getWidgetData() -> WidgetData? {
+        guard let data = userDefaults?.data(forKey: "widgetData"),
+              let widgetData = try? JSONDecoder().decode(WidgetData.self, from: data) else {
+            return nil
+        }
+        return widgetData
+    }
+}
+
+struct WidgetData: Codable {
+    let milesDriven: Int
+    let remainingMiles: Int
+    let monthsLeft: Int
+    let projectedOverage: Int
+    let lastUpdated: Date
+}

--- a/LeaseMilesTracker/Tests/NotificationManagerTests.swift
+++ b/LeaseMilesTracker/Tests/NotificationManagerTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+import UserNotifications
+@testable import LeaseMilesTracker
+
+@MainActor
+class NotificationManagerTests: XCTestCase {
+    var notificationManager: NotificationManager!
+    
+    override func setUp() {
+        super.setUp()
+        notificationManager = NotificationManager.shared
+    }
+    
+    override func tearDown() {
+        // Clean up any test notifications
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+        super.tearDown()
+    }
+    
+    func testNotificationManagerInitialization() {
+        XCTAssertNotNil(notificationManager)
+        XCTAssertEqual(notificationManager.authorizationStatus, .notDetermined)
+    }
+    
+    func testRequestPermission() async {
+        let granted = await notificationManager.requestPermission()
+        // Note: This test may fail in simulator without user interaction
+        // In a real test environment, you'd mock the notification center
+        XCTAssertTrue(granted || !granted) // Either result is valid
+    }
+    
+    func testSendTestNotification() {
+        // This test verifies the method doesn't crash
+        // Actual notification delivery depends on permissions
+        notificationManager.sendTestNotification()
+        
+        // Verify no crash occurred
+        XCTAssertTrue(true)
+    }
+    
+    func testScheduleTestReminder() {
+        // Test scheduling a reminder
+        notificationManager.scheduleTestReminder(seconds: 1)
+        
+        // Verify no crash occurred
+        XCTAssertTrue(true)
+    }
+    
+    func testCancelTestReminder() {
+        // Test canceling reminders
+        notificationManager.cancelTestReminder()
+        
+        // Verify no crash occurred
+        XCTAssertTrue(true)
+    }
+    
+    func testSendThresholdAlert() {
+        // Test threshold alert
+        notificationManager.sendThresholdAlert(milesDriven: 25000, thresholdPercent: 90, projectedOverage: 5000)
+        
+        // Verify no crash occurred
+        XCTAssertTrue(true)
+    }
+    
+    func testGetPendingNotifications() async {
+        let pendingNotifications = await notificationManager.getPendingNotifications()
+        // Should return empty array initially
+        XCTAssertTrue(pendingNotifications.isEmpty)
+    }
+    
+    func testGetDeliveredNotifications() async {
+        let deliveredNotifications = await notificationManager.getDeliveredNotifications()
+        // Should return empty array initially
+        XCTAssertTrue(deliveredNotifications.isEmpty)
+    }
+}

--- a/LeaseMilesTracker/Tests/SharedDataManagerTests.swift
+++ b/LeaseMilesTracker/Tests/SharedDataManagerTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import LeaseMilesTracker
+
+class SharedDataManagerTests: XCTestCase {
+    var sharedDataManager: SharedDataManager!
+    
+    override func setUp() {
+        super.setUp()
+        sharedDataManager = SharedDataManager.shared
+    }
+    
+    func testSharedDataManagerSingleton() {
+        let instance1 = SharedDataManager.shared
+        let instance2 = SharedDataManager.shared
+        XCTAssertIdentical(instance1, instance2)
+    }
+    
+    func testWidgetDataEncoding() {
+        let widgetData = WidgetData(
+            milesDriven: 15000,
+            remainingMiles: 21000,
+            monthsLeft: 18,
+            projectedOverage: 0,
+            lastUpdated: Date()
+        )
+        
+        // Test encoding
+        let encodedData = try? JSONEncoder().encode(widgetData)
+        XCTAssertNotNil(encodedData)
+        
+        // Test decoding
+        let decodedData = try? JSONDecoder().decode(WidgetData.self, from: encodedData!)
+        XCTAssertNotNil(decodedData)
+        XCTAssertEqual(decodedData?.milesDriven, 15000)
+        XCTAssertEqual(decodedData?.remainingMiles, 21000)
+        XCTAssertEqual(decodedData?.monthsLeft, 18)
+        XCTAssertEqual(decodedData?.projectedOverage, 0)
+    }
+    
+    func testWidgetDataWithOverage() {
+        let widgetData = WidgetData(
+            milesDriven: 35000,
+            remainingMiles: 1000,
+            monthsLeft: 6,
+            projectedOverage: 5000,
+            lastUpdated: Date()
+        )
+        
+        let encodedData = try? JSONEncoder().encode(widgetData)
+        XCTAssertNotNil(encodedData)
+        
+        let decodedData = try? JSONDecoder().decode(WidgetData.self, from: encodedData!)
+        XCTAssertNotNil(decodedData)
+        XCTAssertEqual(decodedData?.projectedOverage, 5000)
+    }
+}

--- a/LeaseMilesTracker/Views/Dashboard/DashboardView.swift
+++ b/LeaseMilesTracker/Views/Dashboard/DashboardView.swift
@@ -7,6 +7,7 @@ struct DashboardView: View {
     @Query private var entries: [MileageEntry]
     @State private var showingAddEntry = false
     @State private var showingOnboarding = false
+    @State private var showingNotificationTest = false
     
     private var settingsStore: LeaseSettingsStore {
         LeaseSettingsStore(modelContext: modelContext)
@@ -103,19 +104,35 @@ struct DashboardView: View {
             .navigationTitle("Dashboard")
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button {
-                        showingAddEntry = true
-                    } label: {
-                        Image(systemName: "plus.circle.fill")
+                    HStack {
+                        Button {
+                            showingNotificationTest = true
+                        } label: {
+                            Image(systemName: "bell.badge")
+                        }
+                        
+                        Button {
+                            showingAddEntry = true
+                        } label: {
+                            Image(systemName: "plus.circle.fill")
+                        }
                     }
                 }
             }
             .sheet(isPresented: $showingAddEntry) {
                 AddEntryView()
             }
+            .sheet(isPresented: $showingNotificationTest) {
+                NotificationTestView()
+            }
             .onAppear {
                 if settings.isEmpty {
                     showingOnboarding = true
+                } else {
+                    // Update widget data when dashboard appears
+                    if let leaseSettings = settings.first {
+                        SharedDataManager.shared.updateWidgetData(settings: leaseSettings, entries: entries)
+                    }
                 }
             }
             .sheet(isPresented: $showingOnboarding) {

--- a/LeaseMilesTracker/Views/Testing/NotificationTestView.swift
+++ b/LeaseMilesTracker/Views/Testing/NotificationTestView.swift
@@ -1,0 +1,246 @@
+import SwiftUI
+import UserNotifications
+
+struct NotificationTestView: View {
+    @StateObject private var notificationManager = NotificationManager.shared
+    @State private var showingAlert = false
+    @State private var alertMessage = ""
+    @State private var testScheduled = false
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("Notification Testing")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    
+                    Text("Test your notification settings and schedule test alerts.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                
+                VStack(spacing: 16) {
+                    // Permission Status
+                    HStack {
+                        Image(systemName: notificationIcon)
+                            .foregroundColor(notificationColor)
+                        VStack(alignment: .leading) {
+                            Text("Permission Status")
+                                .font(.headline)
+                            Text(permissionStatusText)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                    }
+                    .padding()
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(12)
+                    
+                    // Test Buttons
+                    VStack(spacing: 12) {
+                        Button(action: requestPermission) {
+                            HStack {
+                                Image(systemName: "bell.badge")
+                                Text("Request Permission")
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.blue)
+                            .foregroundColor(.white)
+                            .cornerRadius(12)
+                        }
+                        .disabled(notificationManager.authorizationStatus == .authorized)
+                        
+                        Button(action: sendTestNotification) {
+                            HStack {
+                                Image(systemName: "paperplane")
+                                Text("Send Test Notification")
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.green)
+                            .foregroundColor(.white)
+                            .cornerRadius(12)
+                        }
+                        .disabled(notificationManager.authorizationStatus != .authorized)
+                        
+                        Button(action: scheduleTestReminder) {
+                            HStack {
+                                Image(systemName: "clock")
+                                Text(testScheduled ? "Cancel Test Reminder" : "Schedule Test Reminder (5s)")
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(testScheduled ? Color.red : Color.orange)
+                            .foregroundColor(.white)
+                            .cornerRadius(12)
+                        }
+                        .disabled(notificationManager.authorizationStatus != .authorized)
+                        
+                        Button(action: testThresholdAlert) {
+                            HStack {
+                                Image(systemName: "exclamationmark.triangle")
+                                Text("Test Threshold Alert")
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.purple)
+                            .foregroundColor(.white)
+                            .cornerRadius(12)
+                        }
+                        .disabled(notificationManager.authorizationStatus != .authorized)
+                    }
+                }
+                
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("Notification Test")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") {
+                        // Dismiss the view
+                    }
+                }
+            }
+            .alert("Notification Test", isPresented: $showingAlert) {
+                Button("OK") { }
+            } message: {
+                Text(alertMessage)
+            }
+            .onAppear {
+                notificationManager.checkAuthorizationStatus()
+            }
+        }
+    }
+    
+    private var notificationIcon: String {
+        switch notificationManager.authorizationStatus {
+        case .authorized:
+            return "checkmark.circle.fill"
+        case .denied:
+            return "xmark.circle.fill"
+        case .notDetermined:
+            return "questionmark.circle.fill"
+        case .provisional:
+            return "exclamationmark.circle.fill"
+        case .ephemeral:
+            return "clock.circle.fill"
+        @unknown default:
+            return "questionmark.circle.fill"
+        }
+    }
+    
+    private var notificationColor: Color {
+        switch notificationManager.authorizationStatus {
+        case .authorized:
+            return .green
+        case .denied:
+            return .red
+        case .notDetermined:
+            return .orange
+        case .provisional:
+            return .blue
+        case .ephemeral:
+            return .purple
+        @unknown default:
+            return .gray
+        }
+    }
+    
+    private var permissionStatusText: String {
+        switch notificationManager.authorizationStatus {
+        case .authorized:
+            return "Notifications are enabled"
+        case .denied:
+            return "Notifications are disabled. Enable in Settings."
+        case .notDetermined:
+            return "Permission not requested yet"
+        case .provisional:
+            return "Provisional notifications enabled"
+        case .ephemeral:
+            return "Ephemeral notifications enabled"
+        @unknown default:
+            return "Unknown status"
+        }
+    }
+    
+    private func requestPermission() {
+        Task {
+            let granted = await notificationManager.requestPermission()
+            await MainActor.run {
+                if granted {
+                    alertMessage = "Notification permission granted!"
+                } else {
+                    alertMessage = "Notification permission denied. Please enable in Settings."
+                }
+                showingAlert = true
+            }
+        }
+    }
+    
+    private func sendTestNotification() {
+        let content = UNMutableNotificationContent()
+        content.title = "Test Notification"
+        content.body = "This is a test notification from Lease Miles Tracker!"
+        content.sound = .default
+        
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(identifier: "test-notification", content: content, trigger: trigger)
+        
+        UNUserNotificationCenter.current().add(request) { error in
+            DispatchQueue.main.async {
+                if let error = error {
+                    alertMessage = "Error sending test notification: \(error.localizedDescription)"
+                } else {
+                    alertMessage = "Test notification sent!"
+                }
+                showingAlert = true
+            }
+        }
+    }
+    
+    private func scheduleTestReminder() {
+        if testScheduled {
+            // Cancel the test reminder
+            UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ["test-reminder"])
+            testScheduled = false
+            alertMessage = "Test reminder cancelled"
+        } else {
+            // Schedule a test reminder for 5 seconds
+            let content = UNMutableNotificationContent()
+            content.title = "Test Reminder"
+            content.body = "This is a test reminder scheduled 5 seconds ago!"
+            content.sound = .default
+            
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
+            let request = UNNotificationRequest(identifier: "test-reminder", content: content, trigger: trigger)
+            
+            UNUserNotificationCenter.current().add(request) { error in
+                DispatchQueue.main.async {
+                    if let error = error {
+                        alertMessage = "Error scheduling test reminder: \(error.localizedDescription)"
+                    } else {
+                        testScheduled = true
+                        alertMessage = "Test reminder scheduled for 5 seconds!"
+                    }
+                    showingAlert = true
+                }
+            }
+        }
+    }
+    
+    private func testThresholdAlert() {
+        notificationManager.sendThresholdAlert(milesDriven: 25000, thresholdPercent: 90, projectedOverage: 5000)
+        alertMessage = "Threshold alert sent! Check your notifications."
+        showingAlert = true
+    }
+}
+
+#Preview {
+    NotificationTestView()
+}

--- a/LeaseMilesTracker/WIDGET_AND_NOTIFICATIONS.md
+++ b/LeaseMilesTracker/WIDGET_AND_NOTIFICATIONS.md
@@ -1,0 +1,122 @@
+# Widget and Notifications Guide
+
+## Widget Features
+
+The Lease Miles Tracker now includes a comprehensive widget system that allows you to track your lease mileage directly from your home screen.
+
+### Widget Sizes
+
+#### Small Widget
+- Displays miles driven and remaining miles
+- Shows projected overage warning if applicable
+- Compact design perfect for quick glances
+
+#### Medium Widget
+- Shows miles driven and remaining miles side by side
+- Displays months left and projected overage
+- More detailed information in a horizontal layout
+
+#### Large Widget
+- Grid layout with all key metrics
+- Miles driven, remaining miles, months left
+- Status indicator (On Track or Projected Over)
+- Most comprehensive view of your lease status
+
+### Adding the Widget
+
+1. Long press on your home screen
+2. Tap the "+" button in the top-left corner
+3. Search for "Lease Miles Tracker"
+4. Select the widget size you prefer
+5. Tap "Add Widget"
+
+### Widget Data
+
+The widget automatically updates with your latest lease data:
+- Updates every hour
+- Shows real-time calculations
+- Displays warnings for projected overages
+- Falls back to "No Data" state if app hasn't been set up
+
+## Notification Features
+
+### Notification Testing
+
+The app now includes a comprehensive notification testing system accessible from the dashboard:
+
+1. Tap the bell icon in the top-right corner of the dashboard
+2. Test different notification types:
+   - **Request Permission**: Enable notifications if not already enabled
+   - **Send Test Notification**: Immediate test notification
+   - **Schedule Test Reminder**: 5-second delayed notification
+   - **Test Threshold Alert**: Simulate mileage threshold warning
+
+### Notification Types
+
+#### Monthly Reminders
+- Configurable day of the month
+- Reminds you to update your odometer reading
+- Can be set in Settings
+
+#### Threshold Alerts
+- Automatic alerts when you reach 90% of allowed mileage
+- Projected overage warnings
+- Immediate notifications for critical situations
+
+#### Test Notifications
+- Verify notification permissions
+- Test notification delivery
+- Debug notification issues
+
+### Notification Settings
+
+Access notification settings through:
+1. Dashboard → Settings (gear icon)
+2. Notification section
+3. Configure reminder day and threshold percentage
+
+## Technical Implementation
+
+### App Groups
+The widget uses App Groups to share data between the main app and widget:
+- Group ID: `group.com.leasemilestracker.shared`
+- Shared UserDefaults for data persistence
+- Automatic widget timeline updates
+
+### Data Sharing
+- `SharedDataManager` handles data synchronization
+- Widget data updates when dashboard is viewed
+- JSON encoding for cross-process communication
+
+### Widget Timeline
+- Updates every hour automatically
+- Manual refresh when app is opened
+- Efficient data loading with fallbacks
+
+## Troubleshooting
+
+### Widget Not Updating
+1. Ensure the main app has been opened at least once
+2. Check that lease settings are complete
+3. Try removing and re-adding the widget
+4. Restart the device if issues persist
+
+### Notifications Not Working
+1. Check notification permissions in Settings
+2. Use the notification test feature in the app
+3. Ensure Do Not Disturb is not enabled
+4. Verify notification settings in iOS Settings
+
+### Data Not Syncing
+1. Open the main app to trigger data sync
+2. Check that App Groups are properly configured
+3. Verify lease settings are complete
+4. Try logging out and back in
+
+## Future Enhancements
+
+- Interactive widget buttons for quick actions
+- Multiple widget configurations
+- Customizable widget appearance
+- Advanced notification scheduling
+- Widget complications for Apple Watch

--- a/LeaseMilesTracker/Widget/LeaseMilesWidget.swift
+++ b/LeaseMilesTracker/Widget/LeaseMilesWidget.swift
@@ -1,0 +1,308 @@
+import WidgetKit
+import SwiftUI
+import SwiftData
+
+struct LeaseMilesWidget: Widget {
+    let kind: String = "LeaseMilesWidget"
+
+    var body: some WidgetConfiguration {
+        IntentConfiguration(kind: kind, intent: LeaseMilesWidgetConfiguration.self, provider: LeaseMilesProvider()) { entry in
+            LeaseMilesWidgetEntryView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("Lease Miles Tracker")
+        .description("Track your lease mileage and remaining miles at a glance.")
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+    }
+}
+
+struct LeaseMilesProvider: TimelineProvider {
+    func placeholder(in context: Context) -> LeaseMilesEntry {
+        LeaseMilesEntry(
+            date: Date(),
+            milesDriven: 15000,
+            remainingMiles: 21000,
+            monthsLeft: 18,
+            projectedOverage: 0,
+            isDataAvailable: true
+        )
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (LeaseMilesEntry) -> ()) {
+        let entry = loadLeaseData()
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<LeaseMilesEntry>) -> ()) {
+        let entry = loadLeaseData()
+        
+        // Update every hour
+        let nextUpdate = Calendar.current.date(byAdding: .hour, value: 1, to: Date()) ?? Date()
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        completion(timeline)
+    }
+    
+    private func loadLeaseData() -> LeaseMilesEntry {
+        guard let widgetData = SharedDataManager.shared.getWidgetData() else {
+            return LeaseMilesEntry(
+                date: Date(),
+                milesDriven: 0,
+                remainingMiles: 0,
+                monthsLeft: 0,
+                projectedOverage: 0,
+                isDataAvailable: false
+            )
+        }
+        
+        return LeaseMilesEntry(
+            date: widgetData.lastUpdated,
+            milesDriven: widgetData.milesDriven,
+            remainingMiles: widgetData.remainingMiles,
+            monthsLeft: widgetData.monthsLeft,
+            projectedOverage: widgetData.projectedOverage,
+            isDataAvailable: true
+        )
+    }
+}
+
+struct LeaseMilesEntry: TimelineEntry {
+    let date: Date
+    let milesDriven: Int
+    let remainingMiles: Int
+    let monthsLeft: Int
+    let projectedOverage: Int
+    let isDataAvailable: Bool
+}
+
+struct LeaseMilesWidgetEntryView: View {
+    var entry: LeaseMilesProvider.Entry
+    @Environment(\.widgetFamily) var family
+
+    var body: some View {
+        if entry.isDataAvailable {
+            switch family {
+            case .systemSmall:
+                SmallWidgetView(entry: entry)
+            case .systemMedium:
+                MediumWidgetView(entry: entry)
+            case .systemLarge:
+                LargeWidgetView(entry: entry)
+            default:
+                SmallWidgetView(entry: entry)
+            }
+        } else {
+            NoDataView()
+        }
+    }
+}
+
+struct SmallWidgetView: View {
+    let entry: LeaseMilesEntry
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "car.fill")
+                    .foregroundColor(.blue)
+                Text("Lease")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                Spacer()
+            }
+            
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("\(entry.milesDriven.formatted)")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    Text("miles")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                Text("\(entry.remainingMiles.formatted) left")
+                    .font(.caption)
+                    .foregroundColor(entry.remainingMiles > 0 ? .green : .red)
+                
+                if entry.projectedOverage > 0 {
+                    Text("⚠️ \(entry.projectedOverage.formatted)")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .fontWeight(.semibold)
+                }
+            }
+            
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+struct MediumWidgetView: View {
+    let entry: LeaseMilesEntry
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "car.fill")
+                    .foregroundColor(.blue)
+                Text("Lease Tracker")
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                Spacer()
+            }
+            
+            HStack(spacing: 16) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("\(entry.milesDriven.formatted)")
+                        .font(.title)
+                        .fontWeight(.bold)
+                    Text("Miles Driven")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("\(entry.remainingMiles.formatted)")
+                        .font(.title)
+                        .fontWeight(.bold)
+                        .foregroundColor(entry.remainingMiles > 0 ? .green : .red)
+                    Text("Remaining")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                Spacer()
+            }
+            
+            HStack {
+                Text("\(entry.monthsLeft) months left")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                
+                Spacer()
+                
+                if entry.projectedOverage > 0 {
+                    Text("⚠️ \(entry.projectedOverage.formatted) over")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .fontWeight(.semibold)
+                }
+            }
+            
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+struct LargeWidgetView: View {
+    let entry: LeaseMilesEntry
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Image(systemName: "car.fill")
+                    .foregroundColor(.blue)
+                Text("Lease Miles Tracker")
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                Spacer()
+            }
+            
+            LazyVGrid(columns: [
+                GridItem(.flexible()),
+                GridItem(.flexible())
+            ], spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("\(entry.milesDriven.formatted)")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    Text("Miles Driven")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("\(entry.remainingMiles.formatted)")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .foregroundColor(entry.remainingMiles > 0 ? .green : .red)
+                    Text("Remaining")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("\(entry.monthsLeft)")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    Text("Months Left")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    if entry.projectedOverage > 0 {
+                        Text("\(entry.projectedOverage.formatted)")
+                            .font(.title2)
+                            .fontWeight(.bold)
+                            .foregroundColor(.red)
+                        Text("Projected Over")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    } else {
+                        Text("On Track")
+                            .font(.title2)
+                            .fontWeight(.bold)
+                            .foregroundColor(.green)
+                        Text("Status")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+struct NoDataView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "car")
+                .font(.largeTitle)
+                .foregroundColor(.secondary)
+            Text("No Data")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Text("Open app to set up")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .padding()
+    }
+}
+
+#Preview(as: .systemSmall) {
+    LeaseMilesWidget()
+} timeline: {
+    LeaseMilesEntry(
+        date: .now,
+        milesDriven: 15000,
+        remainingMiles: 21000,
+        monthsLeft: 18,
+        projectedOverage: 0,
+        isDataAvailable: true
+    )
+    LeaseMilesEntry(
+        date: .now,
+        milesDriven: 25000,
+        remainingMiles: 11000,
+        monthsLeft: 12,
+        projectedOverage: 5000,
+        isDataAvailable: true
+    )
+}

--- a/LeaseMilesTracker/Widget/LeaseMilesWidgetBundle.swift
+++ b/LeaseMilesTracker/Widget/LeaseMilesWidgetBundle.swift
@@ -1,0 +1,9 @@
+import WidgetKit
+import SwiftUI
+
+@main
+struct LeaseMilesWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        LeaseMilesWidget()
+    }
+}

--- a/LeaseMilesTracker/Widget/LeaseMilesWidgetConfiguration.swift
+++ b/LeaseMilesTracker/Widget/LeaseMilesWidgetConfiguration.swift
@@ -1,0 +1,33 @@
+import WidgetKit
+import SwiftUI
+
+struct LeaseMilesWidgetConfiguration: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource = "Configuration"
+    static var description = IntentDescription("This is an example widget.")
+
+    @Parameter(title: "Display Style", default: .compact)
+    var displayStyle: DisplayStyle
+    
+    @Parameter(title: "Show Projected Overage", default: true)
+    var showProjectedOverage: NSNumber
+    
+    @Parameter(title: "Show Months Left", default: true)
+    var showMonthsLeft: NSNumber
+    
+    @Parameter(title: "Show Running Cost", default: false)
+    var showRunningCost: NSNumber
+}
+
+enum DisplayStyle: String, CaseIterable, AppEnum {
+    case compact = "compact"
+    case detailed = "detailed"
+    case minimal = "minimal"
+    
+    static var typeDisplayRepresentation: TypeDisplayRepresentation = "Display Style"
+    
+    static var caseDisplayRepresentations: [DisplayStyle: DisplayRepresentation] = [
+        .compact: "Compact",
+        .detailed: "Detailed", 
+        .minimal: "Minimal"
+    ]
+}


### PR DESCRIPTION
Add a home screen widget to display lease mileage data and a dedicated view for testing notification functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c258e8d-5c35-4e69-bd12-c88c6a3b3a05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8c258e8d-5c35-4e69-bd12-c88c6a3b3a05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

