### PR TITLE
Add multiple car support

### DIFF
--- a/LeaseMilesTracker/LeaseMilesTrackerApp.swift
+++ b/LeaseMilesTracker/LeaseMilesTrackerApp.swift
@@ -7,7 +7,7 @@ struct LeaseMilesTrackerApp: App {
     
     init() {
         do {
-            modelContainer = try ModelContainer(for: LeaseSettings.self, MileageEntry.self)
+            modelContainer = try ModelContainer(for: Car.self, MileageEntry.self, LeaseSettings.self)
         } catch {
             fatalError("Could not initialize ModelContainer: \(error)")
         }
@@ -23,15 +23,23 @@ struct LeaseMilesTrackerApp: App {
 
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
-    @Query private var settings: [LeaseSettings]
+    @Query private var cars: [Car]
+    
+    private var carStore: CarStore {
+        CarStore(modelContext: modelContext)
+    }
     
     var body: some View {
         Group {
-            if settings.isEmpty || !settings.first!.isComplete {
+            if cars.isEmpty {
                 OnboardingView()
             } else {
                 MainTabView()
             }
+        }
+        .onAppear {
+            // Migrate from old data if needed
+            carStore.migrateFromOldData()
         }
     }
 }
@@ -49,6 +57,12 @@ struct MainTabView: View {
                 .tabItem {
                     Image(systemName: "clock")
                     Text("History")
+                }
+            
+            CarSelectionView()
+                .tabItem {
+                    Image(systemName: "car.circle")
+                    Text("Cars")
                 }
             
             SettingsView()

--- a/LeaseMilesTracker/Models/Car.swift
+++ b/LeaseMilesTracker/Models/Car.swift
@@ -1,0 +1,90 @@
+import Foundation
+import SwiftData
+
+@Model
+class Car {
+    var id: UUID
+    var name: String
+    var make: String?
+    var model: String?
+    var year: Int?
+    var color: String?
+    var leaseStartDate: Date
+    var leaseEndDate: Date
+    var startingOdometer: Int
+    var allowedMilesTotal: Int
+    var costPerMile: Decimal
+    var reminderDayOfMonth: Int?
+    var lowMilesThresholdPercent: Int
+    var isActive: Bool
+    var dateCreated: Date
+    
+    @Relationship(deleteRule: .cascade, inverse: \MileageEntry.car)
+    var mileageEntries: [MileageEntry] = []
+    
+    init(
+        name: String,
+        make: String? = nil,
+        model: String? = nil,
+        year: Int? = nil,
+        color: String? = nil,
+        leaseStartDate: Date = Date(),
+        leaseEndDate: Date = Calendar.current.date(byAdding: .year, value: 3, to: Date()) ?? Date(),
+        startingOdometer: Int = 0,
+        allowedMilesTotal: Int = 36000,
+        costPerMile: Decimal = 0.25,
+        reminderDayOfMonth: Int? = nil,
+        lowMilesThresholdPercent: Int = 90,
+        isActive: Bool = true
+    ) {
+        self.id = UUID()
+        self.name = name
+        self.make = make
+        self.model = model
+        self.year = year
+        self.color = color
+        self.leaseStartDate = leaseStartDate
+        self.leaseEndDate = leaseEndDate
+        self.startingOdometer = startingOdometer
+        self.allowedMilesTotal = allowedMilesTotal
+        self.costPerMile = costPerMile
+        self.reminderDayOfMonth = reminderDayOfMonth
+        self.lowMilesThresholdPercent = lowMilesThresholdPercent
+        self.isActive = isActive
+        self.dateCreated = Date()
+    }
+    
+    var displayName: String {
+        if let make = make, let model = model {
+            return "\(year.map { "\($0) " } ?? "")\(make) \(model)"
+        } else {
+            return name
+        }
+    }
+    
+    var isComplete: Bool {
+        return startingOdometer > 0 && allowedMilesTotal > 0 && costPerMile > 0 && !name.isEmpty
+    }
+    
+    var leaseSettings: LeaseSettings {
+        return LeaseSettings(
+            leaseStartDate: leaseStartDate,
+            leaseEndDate: leaseEndDate,
+            startingOdometer: startingOdometer,
+            allowedMilesTotal: allowedMilesTotal,
+            costPerMile: costPerMile,
+            reminderDayOfMonth: reminderDayOfMonth,
+            lowMilesThresholdPercent: lowMilesThresholdPercent
+        )
+    }
+    
+    func updateFromLeaseSettings(_ settings: LeaseSettings) {
+        self.leaseStartDate = settings.leaseStartDate
+        self.leaseEndDate = settings.leaseEndDate
+        self.startingOdometer = settings.startingOdometer
+        self.allowedMilesTotal = settings.allowedMilesTotal
+        self.costPerMile = settings.costPerMile
+        self.reminderDayOfMonth = settings.reminderDayOfMonth
+        self.lowMilesThresholdPercent = settings.lowMilesThresholdPercent
+    }
+}

--- a/LeaseMilesTracker/Models/MileageEntry.swift
+++ b/LeaseMilesTracker/Models/MileageEntry.swift
@@ -7,11 +7,13 @@ class MileageEntry {
     var date: Date
     var odometer: Int
     var notes: String?
+    var car: Car?
     
-    init(date: Date = Date(), odometer: Int, notes: String? = nil) {
+    init(date: Date = Date(), odometer: Int, notes: String? = nil, car: Car? = nil) {
         self.id = UUID()
         self.date = date
         self.odometer = odometer
         self.notes = notes
+        self.car = car
     }
 }

--- a/LeaseMilesTracker/Stores/CarStore.swift
+++ b/LeaseMilesTracker/Stores/CarStore.swift
@@ -1,0 +1,133 @@
+import Foundation
+import SwiftData
+
+@MainActor
+class CarStore: ObservableObject {
+    private var modelContext: ModelContext
+    
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+    
+    func loadCars() -> [Car] {
+        let descriptor = FetchDescriptor<Car>(
+            sortBy: [SortDescriptor(\.isActive, order: .reverse), SortDescriptor(\.dateCreated, order: .reverse)]
+        )
+        return (try? modelContext.fetch(descriptor)) ?? []
+    }
+    
+    func loadActiveCars() -> [Car] {
+        let descriptor = FetchDescriptor<Car>(
+            predicate: #Predicate<Car> { $0.isActive == true },
+            sortBy: [SortDescriptor(\.dateCreated, order: .reverse)]
+        )
+        return (try? modelContext.fetch(descriptor)) ?? []
+    }
+    
+    func getCar(by id: UUID) -> Car? {
+        let descriptor = FetchDescriptor<Car>(
+            predicate: #Predicate<Car> { $0.id == id }
+        )
+        return try? modelContext.fetch(descriptor).first
+    }
+    
+    func addCar(_ car: Car) {
+        modelContext.insert(car)
+        
+        do {
+            try modelContext.save()
+        } catch {
+            print("Error adding car: \(error)")
+        }
+    }
+    
+    func updateCar(_ car: Car) {
+        do {
+            try modelContext.save()
+        } catch {
+            print("Error updating car: \(error)")
+        }
+    }
+    
+    func deleteCar(_ car: Car) {
+        modelContext.delete(car)
+        
+        do {
+            try modelContext.save()
+        } catch {
+            print("Error deleting car: \(error)")
+        }
+    }
+    
+    func setActiveCar(_ car: Car) {
+        // Deactivate all cars first
+        let allCars = loadCars()
+        for existingCar in allCars {
+            existingCar.isActive = false
+        }
+        
+        // Activate the selected car
+        car.isActive = true
+        
+        do {
+            try modelContext.save()
+        } catch {
+            print("Error setting active car: \(error)")
+        }
+    }
+    
+    func getActiveCar() -> Car? {
+        let descriptor = FetchDescriptor<Car>(
+            predicate: #Predicate<Car> { $0.isActive == true }
+        )
+        return try? modelContext.fetch(descriptor).first
+    }
+    
+    func migrateFromOldData() {
+        // This method helps migrate from the old single-car system
+        let cars = loadCars()
+        
+        // If we already have cars, no migration needed
+        if !cars.isEmpty {
+            return
+        }
+        
+        // Check if we have old LeaseSettings data
+        let settingsDescriptor = FetchDescriptor<LeaseSettings>()
+        if let oldSettings = try? modelContext.fetch(settingsDescriptor).first {
+            // Create a new car from the old settings
+            let newCar = Car(
+                name: "My Car",
+                leaseStartDate: oldSettings.leaseStartDate,
+                leaseEndDate: oldSettings.leaseEndDate,
+                startingOdometer: oldSettings.startingOdometer,
+                allowedMilesTotal: oldSettings.allowedMilesTotal,
+                costPerMile: oldSettings.costPerMile,
+                reminderDayOfMonth: oldSettings.reminderDayOfMonth,
+                lowMilesThresholdPercent: oldSettings.lowMilesThresholdPercent,
+                isActive: true
+            )
+            
+            // Get old mileage entries and associate them with the new car
+            let entriesDescriptor = FetchDescriptor<MileageEntry>()
+            let oldEntries = (try? modelContext.fetch(entriesDescriptor)) ?? []
+            
+            for entry in oldEntries {
+                entry.car = newCar
+            }
+            
+            // Add the new car
+            addCar(newCar)
+            
+            // Delete the old settings
+            modelContext.delete(oldSettings)
+            
+            do {
+                try modelContext.save()
+                print("Successfully migrated from old data structure")
+            } catch {
+                print("Error during migration: \(error)")
+            }
+        }
+    }
+}

--- a/LeaseMilesTracker/Stores/MileageStore.swift
+++ b/LeaseMilesTracker/Stores/MileageStore.swift
@@ -9,15 +9,23 @@ class MileageStore: ObservableObject {
         self.modelContext = modelContext
     }
     
-    func loadEntries() -> [MileageEntry] {
+    func loadEntries(for car: Car) -> [MileageEntry] {
+        let descriptor = FetchDescriptor<MileageEntry>(
+            predicate: #Predicate<MileageEntry> { $0.car?.id == car.id },
+            sortBy: [SortDescriptor(\.date, order: .reverse)]
+        )
+        return (try? modelContext.fetch(descriptor)) ?? []
+    }
+    
+    func loadAllEntries() -> [MileageEntry] {
         let descriptor = FetchDescriptor<MileageEntry>(
             sortBy: [SortDescriptor(\.date, order: .reverse)]
         )
         return (try? modelContext.fetch(descriptor)) ?? []
     }
     
-    func addEntry(date: Date, odometer: Int, notes: String?) {
-        let entry = MileageEntry(date: date, odometer: odometer, notes: notes)
+    func addEntry(date: Date, odometer: Int, notes: String?, car: Car) {
+        let entry = MileageEntry(date: date, odometer: odometer, notes: notes, car: car)
         modelContext.insert(entry)
         
         do {
@@ -49,8 +57,18 @@ class MileageStore: ObservableObject {
         }
     }
     
+    func getLatestOdometer(for car: Car) -> Int? {
+        let entries = loadEntries(for: car)
+        return entries.max(by: { $0.date < $1.date })?.odometer
+    }
+    
+    // Legacy method for backward compatibility
+    func loadEntries() -> [MileageEntry] {
+        return loadAllEntries()
+    }
+    
     func getLatestOdometer() -> Int? {
-        let entries = loadEntries()
+        let entries = loadAllEntries()
         return entries.max(by: { $0.date < $1.date })?.odometer
     }
 }

--- a/LeaseMilesTracker/Views/Cars/AddCarView.swift
+++ b/LeaseMilesTracker/Views/Cars/AddCarView.swift
@@ -1,8 +1,10 @@
 import SwiftUI
 import SwiftData
 
-struct OnboardingView: View {
+struct AddCarView: View {
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+    
     @State private var name = ""
     @State private var make = ""
     @State private var model = ""
@@ -15,12 +17,20 @@ struct OnboardingView: View {
     @State private var costPerMile = ""
     @State private var reminderDayOfMonth = ""
     @State private var lowMilesThresholdPercent = "90"
-    @State private var showingAlert = false
-    @State private var alertMessage = ""
-    @State private var isNotificationEnabled = false
+    @State private var isActive = true
     
     private var carStore: CarStore {
         CarStore(modelContext: modelContext)
+    }
+    
+    private var isValid: Bool {
+        !name.isEmpty && 
+        !startingOdometer.isEmpty && 
+        !allowedMilesTotal.isEmpty && 
+        !costPerMile.isEmpty &&
+        Int(startingOdometer) != nil &&
+        Int(allowedMilesTotal) != nil &&
+        Decimal(string: costPerMile) != nil
     }
     
     var body: some View {
@@ -49,85 +59,49 @@ struct OnboardingView: View {
                 Section("Lease Details") {
                     DatePicker("Lease Start Date", selection: $leaseStartDate, displayedComponents: .date)
                     DatePicker("Lease End Date", selection: $leaseEndDate, displayedComponents: .date)
-                }
-                
-                Section("Odometer") {
+                    
                     TextField("Starting Odometer *", text: $startingOdometer)
                         .keyboardType(.numberPad)
-                }
-                
-                Section("Mileage Allowance") {
+                    
                     TextField("Allowed Miles Total *", text: $allowedMilesTotal)
                         .keyboardType(.numberPad)
-                }
-                
-                Section("Cost") {
+                    
                     TextField("Cost Per Mile ($) *", text: $costPerMile)
                         .keyboardType(.decimalPad)
                 }
                 
                 Section("Notifications") {
-                    Toggle("Enable Monthly Reminders", isOn: $isNotificationEnabled)
+                    TextField("Reminder Day of Month (1-31)", text: $reminderDayOfMonth)
+                        .keyboardType(.numberPad)
                     
-                    if isNotificationEnabled {
-                        TextField("Day of Month (1-28)", text: $reminderDayOfMonth)
-                            .keyboardType(.numberPad)
+                    TextField("Low Miles Threshold (%)", text: $lowMilesThresholdPercent)
+                        .keyboardType(.numberPad)
+                }
+                
+                Section("Settings") {
+                    Toggle("Set as Active Car", isOn: $isActive)
+                }
+            }
+            .navigationTitle("Add New Car")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
                     }
                 }
                 
-                Section("Threshold") {
-                    TextField("Low Miles Threshold %", text: $lowMilesThresholdPercent)
-                        .keyboardType(.numberPad)
-                }
-            }
-            .navigationTitle("Add Your First Car")
-            .navigationBarTitleDisplayMode(.large)
-            .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Save") {
                         saveCar()
                     }
-                    .disabled(!isValidInput)
+                    .disabled(!isValid)
                 }
             }
-            .alert("Error", isPresented: $showingAlert) {
-                Button("OK") { }
-            } message: {
-                Text(alertMessage)
-            }
         }
-    }
-    
-    private var isValidInput: Bool {
-        return !name.isEmpty &&
-               !startingOdometer.isEmpty &&
-               !allowedMilesTotal.isEmpty &&
-               !costPerMile.isEmpty &&
-               Int(startingOdometer) != nil &&
-               Int(allowedMilesTotal) != nil &&
-               Double(costPerMile) != nil &&
-               leaseEndDate > leaseStartDate
     }
     
     private func saveCar() {
-        guard let startingOdometerInt = Int(startingOdometer),
-              let allowedMilesTotalInt = Int(allowedMilesTotal),
-              let costPerMileDouble = Double(costPerMile),
-              leaseEndDate > leaseStartDate else {
-            alertMessage = "Please fill in all required fields with valid values."
-            showingAlert = true
-            return
-        }
-        
-        let reminderDay = isNotificationEnabled ? Int(reminderDayOfMonth) : nil
-        let thresholdPercent = Int(lowMilesThresholdPercent) ?? 90
-        
-        if let reminderDay = reminderDay, (reminderDay < 1 || reminderDay > 28) {
-            alertMessage = "Reminder day must be between 1 and 28."
-            showingAlert = true
-            return
-        }
-        
         let newCar = Car(
             name: name,
             make: make.isEmpty ? nil : make,
@@ -136,24 +110,25 @@ struct OnboardingView: View {
             color: color.isEmpty ? nil : color,
             leaseStartDate: leaseStartDate,
             leaseEndDate: leaseEndDate,
-            startingOdometer: startingOdometerInt,
-            allowedMilesTotal: allowedMilesTotalInt,
-            costPerMile: Decimal(costPerMileDouble),
-            reminderDayOfMonth: reminderDay,
-            lowMilesThresholdPercent: thresholdPercent,
-            isActive: true
+            startingOdometer: Int(startingOdometer) ?? 0,
+            allowedMilesTotal: Int(allowedMilesTotal) ?? 36000,
+            costPerMile: Decimal(string: costPerMile) ?? 0.25,
+            reminderDayOfMonth: reminderDayOfMonth.isEmpty ? nil : Int(reminderDayOfMonth),
+            lowMilesThresholdPercent: Int(lowMilesThresholdPercent) ?? 90,
+            isActive: isActive
         )
         
         carStore.addCar(newCar)
         
-        // Request notification permission if enabled
-        if isNotificationEnabled {
-            Task {
-                let granted = await NotificationManager.shared.requestPermission()
-                if granted, let day = reminderDay {
-                    NotificationManager.shared.scheduleMonthlyReminder(dayOfMonth: day)
-                }
-            }
+        if isActive {
+            carStore.setActiveCar(newCar)
         }
+        
+        dismiss()
     }
+}
+
+#Preview {
+    AddCarView()
+        .modelContainer(for: [Car.self, MileageEntry.self])
 }

--- a/LeaseMilesTracker/Views/Cars/CarSelectionView.swift
+++ b/LeaseMilesTracker/Views/Cars/CarSelectionView.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+import SwiftData
+
+struct CarSelectionView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query private var cars: [Car]
+    @State private var showingAddCar = false
+    @State private var showingEditCar: Car?
+    
+    private var carStore: CarStore {
+        CarStore(modelContext: modelContext)
+    }
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                if cars.isEmpty {
+                    emptyStateView
+                } else {
+                    carsListView
+                }
+            }
+            .navigationTitle("My Cars")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        showingAddCar = true
+                    } label: {
+                        Image(systemName: "plus.circle.fill")
+                    }
+                }
+            }
+            .sheet(isPresented: $showingAddCar) {
+                AddCarView()
+            }
+            .sheet(item: $showingEditCar) { car in
+                EditCarView(car: car)
+            }
+        }
+    }
+    
+    private var emptyStateView: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "car.circle")
+                .font(.system(size: 80))
+                .foregroundColor(.gray)
+            
+            Text("No Cars Added")
+                .font(.title2)
+                .fontWeight(.semibold)
+            
+            Text("Add your first car to start tracking lease mileage")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+            
+            Button {
+                showingAddCar = true
+            } label: {
+                Text("Add Your First Car")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .padding()
+                    .background(Color.blue)
+                    .cornerRadius(12)
+            }
+        }
+        .padding()
+    }
+    
+    private var carsListView: some View {
+        List {
+            ForEach(cars, id: \.id) { car in
+                CarRowView(car: car, onTap: {
+                    carStore.setActiveCar(car)
+                }, onEdit: {
+                    showingEditCar = car
+                })
+            }
+            .onDelete(perform: deleteCars)
+        }
+    }
+    
+    private func deleteCars(offsets: IndexSet) {
+        for index in offsets {
+            let car = cars[index]
+            carStore.deleteCar(car)
+        }
+    }
+}
+
+struct CarRowView: View {
+    let car: Car
+    let onTap: () -> Void
+    let onEdit: () -> Void
+    
+    var body: some View {
+        Button(action: onTap) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(car.displayName)
+                        .font(.headline)
+                        .foregroundColor(.primary)
+                    
+                    if let make = car.make, let model = car.model {
+                        Text("\(car.year.map { "\($0) " } ?? "")\(make) \(model)")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                    
+                    HStack {
+                        Text("Lease: \(car.leaseStartDate.formatted(date: .abbreviated, time: .omitted)) - \(car.leaseEndDate.formatted(date: .abbreviated, time: .omitted))")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        
+                        Spacer()
+                        
+                        if car.isActive {
+                            Text("Active")
+                                .font(.caption)
+                                .fontWeight(.medium)
+                                .foregroundColor(.white)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 2)
+                                .background(Color.blue)
+                                .cornerRadius(4)
+                        }
+                    }
+                }
+                
+                Spacer()
+                
+                Button(action: onEdit) {
+                    Image(systemName: "pencil.circle.fill")
+                        .foregroundColor(.blue)
+                        .font(.title2)
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+            .padding(.vertical, 4)
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+#Preview {
+    CarSelectionView()
+        .modelContainer(for: [Car.self, MileageEntry.self])
+}

--- a/LeaseMilesTracker/Views/Cars/EditCarView.swift
+++ b/LeaseMilesTracker/Views/Cars/EditCarView.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+import SwiftData
+
+struct EditCarView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+    
+    let car: Car
+    
+    @State private var name: String
+    @State private var make: String
+    @State private var model: String
+    @State private var year: String
+    @State private var color: String
+    @State private var leaseStartDate: Date
+    @State private var leaseEndDate: Date
+    @State private var startingOdometer: String
+    @State private var allowedMilesTotal: String
+    @State private var costPerMile: String
+    @State private var reminderDayOfMonth: String
+    @State private var lowMilesThresholdPercent: String
+    @State private var isActive: Bool
+    
+    private var carStore: CarStore {
+        CarStore(modelContext: modelContext)
+    }
+    
+    private var isValid: Bool {
+        !name.isEmpty && 
+        !startingOdometer.isEmpty && 
+        !allowedMilesTotal.isEmpty && 
+        !costPerMile.isEmpty &&
+        Int(startingOdometer) != nil &&
+        Int(allowedMilesTotal) != nil &&
+        Decimal(string: costPerMile) != nil
+    }
+    
+    init(car: Car) {
+        self.car = car
+        self._name = State(initialValue: car.name)
+        self._make = State(initialValue: car.make ?? "")
+        self._model = State(initialValue: car.model ?? "")
+        self._year = State(initialValue: car.year?.description ?? "")
+        self._color = State(initialValue: car.color ?? "")
+        self._leaseStartDate = State(initialValue: car.leaseStartDate)
+        self._leaseEndDate = State(initialValue: car.leaseEndDate)
+        self._startingOdometer = State(initialValue: car.startingOdometer.description)
+        self._allowedMilesTotal = State(initialValue: car.allowedMilesTotal.description)
+        self._costPerMile = State(initialValue: car.costPerMile.description)
+        self._reminderDayOfMonth = State(initialValue: car.reminderDayOfMonth?.description ?? "")
+        self._lowMilesThresholdPercent = State(initialValue: car.lowMilesThresholdPercent.description)
+        self._isActive = State(initialValue: car.isActive)
+    }
+    
+    var body: some View {
+        NavigationView {
+            Form {
+                Section("Car Information") {
+                    TextField("Car Name *", text: $name)
+                        .textContentType(.name)
+                    
+                    HStack {
+                        TextField("Make", text: $make)
+                            .textContentType(.organizationName)
+                        
+                        TextField("Model", text: $model)
+                            .textContentType(.organizationName)
+                    }
+                    
+                    HStack {
+                        TextField("Year", text: $year)
+                            .keyboardType(.numberPad)
+                        
+                        TextField("Color", text: $color)
+                    }
+                }
+                
+                Section("Lease Details") {
+                    DatePicker("Lease Start Date", selection: $leaseStartDate, displayedComponents: .date)
+                    DatePicker("Lease End Date", selection: $leaseEndDate, displayedComponents: .date)
+                    
+                    TextField("Starting Odometer *", text: $startingOdometer)
+                        .keyboardType(.numberPad)
+                    
+                    TextField("Allowed Miles Total *", text: $allowedMilesTotal)
+                        .keyboardType(.numberPad)
+                    
+                    TextField("Cost Per Mile ($) *", text: $costPerMile)
+                        .keyboardType(.decimalPad)
+                }
+                
+                Section("Notifications") {
+                    TextField("Reminder Day of Month (1-31)", text: $reminderDayOfMonth)
+                        .keyboardType(.numberPad)
+                    
+                    TextField("Low Miles Threshold (%)", text: $lowMilesThresholdPercent)
+                        .keyboardType(.numberPad)
+                }
+                
+                Section("Settings") {
+                    Toggle("Set as Active Car", isOn: $isActive)
+                }
+            }
+            .navigationTitle("Edit Car")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+                
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Save") {
+                        saveCar()
+                    }
+                    .disabled(!isValid)
+                }
+            }
+        }
+    }
+    
+    private func saveCar() {
+        car.name = name
+        car.make = make.isEmpty ? nil : make
+        car.model = model.isEmpty ? nil : model
+        car.year = year.isEmpty ? nil : Int(year)
+        car.color = color.isEmpty ? nil : color
+        car.leaseStartDate = leaseStartDate
+        car.leaseEndDate = leaseEndDate
+        car.startingOdometer = Int(startingOdometer) ?? 0
+        car.allowedMilesTotal = Int(allowedMilesTotal) ?? 36000
+        car.costPerMile = Decimal(string: costPerMile) ?? 0.25
+        car.reminderDayOfMonth = reminderDayOfMonth.isEmpty ? nil : Int(reminderDayOfMonth)
+        car.lowMilesThresholdPercent = Int(lowMilesThresholdPercent) ?? 90
+        
+        if isActive && !car.isActive {
+            carStore.setActiveCar(car)
+        } else {
+            car.isActive = isActive
+        }
+        
+        carStore.updateCar(car)
+        dismiss()
+    }
+}
+
+#Preview {
+    let car = Car(name: "Test Car", make: "Toyota", model: "Camry", year: 2023)
+    return EditCarView(car: car)
+        .modelContainer(for: [Car.self, MileageEntry.self])
+}

--- a/LeaseMilesTracker/Views/Dashboard/DashboardView.swift
+++ b/LeaseMilesTracker/Views/Dashboard/DashboardView.swift
@@ -3,29 +3,40 @@ import SwiftData
 
 struct DashboardView: View {
     @Environment(\.modelContext) private var modelContext
-    @Query private var settings: [LeaseSettings]
-    @Query private var entries: [MileageEntry]
+    @Query private var cars: [Car]
     @State private var showingAddEntry = false
-    @State private var showingOnboarding = false
+    @State private var showingCarSelection = false
     
-    private var settingsStore: LeaseSettingsStore {
-        LeaseSettingsStore(modelContext: modelContext)
+    private var carStore: CarStore {
+        CarStore(modelContext: modelContext)
     }
     
     private var mileageStore: MileageStore {
         MileageStore(modelContext: modelContext)
     }
     
+    private var activeCar: Car? {
+        cars.first { $0.isActive }
+    }
+    
+    private var entriesForActiveCar: [MileageEntry] {
+        guard let activeCar = activeCar else { return [] }
+        return mileageStore.loadEntries(for: activeCar)
+    }
+    
     var body: some View {
         NavigationView {
             ScrollView {
                 VStack(spacing: 16) {
-                    if let leaseSettings = settings.first {
-                        let snapshot = LeaseCalculator.calculateSnapshot(settings: leaseSettings, entries: entries)
+                    if let activeCar = activeCar {
+                        let snapshot = LeaseCalculator.calculateSnapshot(settings: activeCar.leaseSettings, entries: entriesForActiveCar)
+                        
+                        // Car Header
+                        carHeaderView(activeCar)
                         
                         // Warning Banner
-                        if LeaseCalculator.shouldShowWarning(settings: leaseSettings, snapshot: snapshot) {
-                            warningBanner(snapshot: snapshot, settings: leaseSettings)
+                        if LeaseCalculator.shouldShowWarning(settings: activeCar.leaseSettings, snapshot: snapshot) {
+                            warningBanner(snapshot: snapshot, settings: activeCar.leaseSettings)
                         }
                         
                         // Metric Cards
@@ -36,7 +47,7 @@ struct DashboardView: View {
                             MetricCard(
                                 title: "Miles Driven",
                                 value: snapshot.milesDriven.formatted,
-                                subtitle: "of \(leaseSettings.allowedMilesTotal.formatted)",
+                                subtitle: "of \(activeCar.allowedMilesTotal.formatted)",
                                 icon: "road.lanes",
                                 color: .blue
                             )
@@ -96,32 +107,111 @@ struct DashboardView: View {
                         }
                         
                         Spacer(minLength: 100)
+                    } else {
+                        // No active car state
+                        noCarStateView
                     }
                 }
                 .padding()
             }
             .navigationTitle("Dashboard")
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .navigationBarLeading) {
                     Button {
-                        showingAddEntry = true
+                        showingCarSelection = true
                     } label: {
-                        Image(systemName: "plus.circle.fill")
+                        Image(systemName: "car.circle.fill")
+                    }
+                }
+                
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if activeCar != nil {
+                        Button {
+                            showingAddEntry = true
+                        } label: {
+                            Image(systemName: "plus.circle.fill")
+                        }
                     }
                 }
             }
             .sheet(isPresented: $showingAddEntry) {
-                AddEntryView()
-            }
-            .onAppear {
-                if settings.isEmpty {
-                    showingOnboarding = true
+                if let activeCar = activeCar {
+                    AddEntryView(car: activeCar)
                 }
             }
-            .sheet(isPresented: $showingOnboarding) {
-                OnboardingView()
+            .sheet(isPresented: $showingCarSelection) {
+                CarSelectionView()
+            }
+            .onAppear {
+                // Migrate from old data if needed
+                carStore.migrateFromOldData()
             }
         }
+    }
+    
+    private func carHeaderView(_ car: Car) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "car.circle.fill")
+                    .foregroundColor(.blue)
+                    .font(.title2)
+                
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(car.displayName)
+                        .font(.headline)
+                        .foregroundColor(.primary)
+                    
+                    if let make = car.make, let model = car.model {
+                        Text("\(car.year.map { "\($0) " } ?? "")\(make) \(model)")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                
+                Spacer()
+                
+                Text("Active")
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.blue)
+                    .cornerRadius(6)
+            }
+        }
+        .padding()
+        .background(Color.blue.opacity(0.1))
+        .cornerRadius(12)
+    }
+    
+    private var noCarStateView: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "car.circle")
+                .font(.system(size: 80))
+                .foregroundColor(.gray)
+            
+            Text("No Active Car")
+                .font(.title2)
+                .fontWeight(.semibold)
+            
+            Text("Select a car from your garage to view the dashboard")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+            
+            Button {
+                showingCarSelection = true
+            } label: {
+                Text("Manage Cars")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .padding()
+                    .background(Color.blue)
+                    .cornerRadius(12)
+            }
+        }
+        .padding()
     }
     
     private func warningBanner(snapshot: LeaseSnapshot, settings: LeaseSettings) -> some View {

--- a/LeaseMilesTracker/Views/Entries/AddEntryView.swift
+++ b/LeaseMilesTracker/Views/Entries/AddEntryView.swift
@@ -4,8 +4,8 @@ import SwiftData
 struct AddEntryView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
-    @Query private var settings: [LeaseSettings]
-    @Query private var entries: [MileageEntry]
+    
+    let car: Car
     
     @State private var date = Date()
     @State private var odometer = ""
@@ -17,9 +17,22 @@ struct AddEntryView: View {
         MileageStore(modelContext: modelContext)
     }
     
+    private var entriesForCar: [MileageEntry] {
+        mileageStore.loadEntries(for: car)
+    }
+    
     var body: some View {
         NavigationView {
             Form {
+                Section("Car") {
+                    HStack {
+                        Image(systemName: "car.circle.fill")
+                            .foregroundColor(.blue)
+                        Text(car.displayName)
+                            .font(.headline)
+                    }
+                }
+                
                 Section("Entry Details") {
                     DatePicker("Date", selection: $date, displayedComponents: .date)
                     
@@ -61,18 +74,17 @@ struct AddEntryView: View {
     }
     
     private func saveEntry() {
-        guard let odometerInt = Int(odometer),
-              let leaseSettings = settings.first else {
+        guard let odometerInt = Int(odometer) else {
             alertMessage = "Invalid odometer reading."
             showingAlert = true
             return
         }
         
-        let latestOdometer = mileageStore.getLatestOdometer() ?? leaseSettings.startingOdometer
+        let latestOdometer = mileageStore.getLatestOdometer(for: car) ?? car.startingOdometer
         let validation = LeaseCalculator.validateOdometerEntry(
             newOdometer: odometerInt,
             previousOdometer: latestOdometer,
-            startingOdometer: leaseSettings.startingOdometer
+            startingOdometer: car.startingOdometer
         )
         
         switch validation {
@@ -87,7 +99,8 @@ struct AddEntryView: View {
         let entry = MileageEntry(
             date: date,
             odometer: odometerInt,
-            notes: notes.isEmpty ? nil : notes
+            notes: notes.isEmpty ? nil : notes,
+            car: car
         )
         
         modelContext.insert(entry)
@@ -96,11 +109,12 @@ struct AddEntryView: View {
             try modelContext.save()
             
             // Check if we should send a threshold alert
-            let snapshot = LeaseCalculator.calculateSnapshot(settings: leaseSettings, entries: entries + [entry])
-            if LeaseCalculator.shouldShowWarning(settings: leaseSettings, snapshot: snapshot) {
+            let updatedEntries = entriesForCar + [entry]
+            let snapshot = LeaseCalculator.calculateSnapshot(settings: car.leaseSettings, entries: updatedEntries)
+            if LeaseCalculator.shouldShowWarning(settings: car.leaseSettings, snapshot: snapshot) {
                 NotificationManager.shared.sendThresholdAlert(
                     milesDriven: snapshot.milesDriven,
-                    thresholdPercent: leaseSettings.lowMilesThresholdPercent,
+                    thresholdPercent: car.lowMilesThresholdPercent,
                     projectedOverage: snapshot.projectedOverage
                 )
             }
@@ -111,4 +125,10 @@ struct AddEntryView: View {
             showingAlert = true
         }
     }
+}
+
+#Preview {
+    let car = Car(name: "Test Car", make: "Toyota", model: "Camry", year: 2023)
+    return AddEntryView(car: car)
+        .modelContainer(for: [Car.self, MileageEntry.self])
 }

--- a/LeaseMilesTracker/Views/Entries/HistoryView.swift
+++ b/LeaseMilesTracker/Views/Entries/HistoryView.swift
@@ -3,8 +3,8 @@ import SwiftData
 
 struct HistoryView: View {
     @Environment(\.modelContext) private var modelContext
-    @Query(sort: \MileageEntry.date, order: .reverse) private var entries: [MileageEntry]
-    @Query private var settings: [LeaseSettings]
+    @Query private var cars: [Car]
+    @Query(sort: \MileageEntry.date, order: .reverse) private var allEntries: [MileageEntry]
     
     @State private var showingAddEntry = false
     @State private var showingEditEntry: MileageEntry?
@@ -13,58 +13,50 @@ struct HistoryView: View {
     @State private var showingShareSheet = false
     @State private var csvFileURL: URL?
     
+    private var carStore: CarStore {
+        CarStore(modelContext: modelContext)
+    }
+    
     private var mileageStore: MileageStore {
         MileageStore(modelContext: modelContext)
+    }
+    
+    private var activeCar: Car? {
+        cars.first { $0.isActive }
+    }
+    
+    private var entries: [MileageEntry] {
+        guard let activeCar = activeCar else { return [] }
+        return mileageStore.loadEntries(for: activeCar)
     }
     
     var body: some View {
         NavigationView {
             Group {
-                if entries.isEmpty {
-                    VStack(spacing: 16) {
-                        Image(systemName: "clock")
-                            .font(.system(size: 60))
-                            .foregroundColor(.secondary)
-                        
-                        Text("No Entries Yet")
-                            .font(.title2)
-                            .fontWeight(.semibold)
-                        
-                        Text("Add your first odometer reading to get started.")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                            .multilineTextAlignment(.center)
-                        
-                        Button("Add Entry") {
-                            showingAddEntry = true
-                        }
-                        .buttonStyle(.borderedProminent)
-                    }
-                    .padding()
+                if activeCar == nil {
+                    noCarStateView
+                } else if entries.isEmpty {
+                    noEntriesStateView
                 } else {
-                    List {
-                        ForEach(entries) { entry in
-                            EntryRowView(
-                                entry: entry,
-                                previousEntry: getPreviousEntry(for: entry)
-                            )
-                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                Button("Delete", role: .destructive) {
-                                    entryToDelete = entry
-                                    showingDeleteAlert = true
-                                }
-                                
-                                Button("Edit") {
-                                    showingEditEntry = entry
-                                }
-                                .tint(.blue)
-                            }
-                        }
-                    }
+                    entriesListView
                 }
             }
             .navigationTitle("History")
             .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        // Show car selection or current car info
+                    } label: {
+                        HStack {
+                            Image(systemName: "car.circle.fill")
+                            if let activeCar = activeCar {
+                                Text(activeCar.displayName)
+                                    .font(.caption)
+                            }
+                        }
+                    }
+                }
+                
                 ToolbarItem(placement: .navigationBarTrailing) {
                     HStack {
                         if !entries.isEmpty {
@@ -75,16 +67,20 @@ struct HistoryView: View {
                             }
                         }
                         
-                        Button {
-                            showingAddEntry = true
-                        } label: {
-                            Image(systemName: "plus")
+                        if activeCar != nil {
+                            Button {
+                                showingAddEntry = true
+                            } label: {
+                                Image(systemName: "plus")
+                            }
                         }
                     }
                 }
             }
             .sheet(isPresented: $showingAddEntry) {
-                AddEntryView()
+                if let activeCar = activeCar {
+                    AddEntryView(car: activeCar)
+                }
             }
             .sheet(item: $showingEditEntry) { entry in
                 EditEntryView(entry: entry)
@@ -103,6 +99,69 @@ struct HistoryView: View {
             .sheet(isPresented: $showingShareSheet) {
                 if let csvFileURL = csvFileURL {
                     ShareSheet(activityItems: [csvFileURL])
+                }
+            }
+        }
+    }
+    
+    private var noCarStateView: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "car.circle")
+                .font(.system(size: 60))
+                .foregroundColor(.secondary)
+            
+            Text("No Active Car")
+                .font(.title2)
+                .fontWeight(.semibold)
+            
+            Text("Select a car from your garage to view its history")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+    }
+    
+    private var noEntriesStateView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "clock")
+                .font(.system(size: 60))
+                .foregroundColor(.secondary)
+            
+            Text("No Entries Yet")
+                .font(.title2)
+                .fontWeight(.semibold)
+            
+            Text("Add your first odometer reading to get started.")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+            
+            Button("Add Entry") {
+                showingAddEntry = true
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+    
+    private var entriesListView: some View {
+        List {
+            ForEach(entries) { entry in
+                EntryRowView(
+                    entry: entry,
+                    previousEntry: getPreviousEntry(for: entry)
+                )
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    Button("Delete", role: .destructive) {
+                        entryToDelete = entry
+                        showingDeleteAlert = true
+                    }
+                    
+                    Button("Edit") {
+                        showingEditEntry = entry
+                    }
+                    .tint(.blue)
                 }
             }
         }

--- a/LeaseMilesTracker/Views/Settings/SettingsView.swift
+++ b/LeaseMilesTracker/Views/Settings/SettingsView.swift
@@ -3,7 +3,7 @@ import SwiftData
 
 struct SettingsView: View {
     @Environment(\.modelContext) private var modelContext
-    @Query private var settings: [LeaseSettings]
+    @Query private var cars: [Car]
     @StateObject private var notificationManager = NotificationManager.shared
     
     @State private var leaseStartDate = Date()
@@ -18,14 +18,27 @@ struct SettingsView: View {
     @State private var showingAlert = false
     @State private var alertMessage = ""
     
-    private var settingsStore: LeaseSettingsStore {
-        LeaseSettingsStore(modelContext: modelContext)
+    private var carStore: CarStore {
+        CarStore(modelContext: modelContext)
+    }
+    
+    private var activeCar: Car? {
+        cars.first { $0.isActive }
     }
     
     var body: some View {
         NavigationView {
             Form {
-                if let leaseSettings = settings.first {
+                if let activeCar = activeCar {
+                    Section("Active Car") {
+                        HStack {
+                            Image(systemName: "car.circle.fill")
+                                .foregroundColor(.blue)
+                            Text(activeCar.displayName)
+                                .font(.headline)
+                        }
+                    }
+                    
                     Section("Lease Details") {
                         DatePicker("Lease Start Date", selection: $leaseStartDate, displayedComponents: .date)
                         DatePicker("Lease End Date", selection: $leaseEndDate, displayedComponents: .date)
@@ -76,13 +89,27 @@ struct SettingsView: View {
                     }
                     
                     Section("Danger Zone") {
-                        Button("Reset All Data", role: .destructive) {
+                        Button("Reset This Car's Data", role: .destructive) {
                             showingResetAlert = true
                         }
                     }
                 } else {
                     Section {
-                        Text("No settings found. Please restart the app.")
+                        VStack(spacing: 16) {
+                            Image(systemName: "car.circle")
+                                .font(.system(size: 60))
+                                .foregroundColor(.secondary)
+                            
+                            Text("No Active Car")
+                                .font(.title2)
+                                .fontWeight(.semibold)
+                            
+                            Text("Select a car from your garage to manage its settings")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                                .multilineTextAlignment(.center)
+                        }
+                        .padding()
                     }
                 }
             }
@@ -95,13 +122,13 @@ struct SettingsView: View {
             } message: {
                 Text(alertMessage)
             }
-            .alert("Reset All Data", isPresented: $showingResetAlert) {
+            .alert("Reset Car Data", isPresented: $showingResetAlert) {
                 Button("Cancel", role: .cancel) { }
                 Button("Reset", role: .destructive) {
-                    resetAllData()
+                    resetCarData()
                 }
             } message: {
-                Text("This will delete all your lease settings and mileage entries. This action cannot be undone.")
+                Text("This will delete all mileage entries for the active car. This action cannot be undone.")
             }
         }
     }
@@ -117,20 +144,21 @@ struct SettingsView: View {
     }
     
     private func loadCurrentSettings() {
-        guard let leaseSettings = settings.first else { return }
+        guard let activeCar = activeCar else { return }
         
-        leaseStartDate = leaseSettings.leaseStartDate
-        leaseEndDate = leaseSettings.leaseEndDate
-        startingOdometer = String(leaseSettings.startingOdometer)
-        allowedMilesTotal = String(leaseSettings.allowedMilesTotal)
-        costPerMile = String(describing: leaseSettings.costPerMile)
-        reminderDayOfMonth = leaseSettings.reminderDayOfMonth.map(String.init) ?? ""
-        lowMilesThresholdPercent = String(leaseSettings.lowMilesThresholdPercent)
-        isNotificationEnabled = leaseSettings.reminderDayOfMonth != nil
+        leaseStartDate = activeCar.leaseStartDate
+        leaseEndDate = activeCar.leaseEndDate
+        startingOdometer = String(activeCar.startingOdometer)
+        allowedMilesTotal = String(activeCar.allowedMilesTotal)
+        costPerMile = String(describing: activeCar.costPerMile)
+        reminderDayOfMonth = activeCar.reminderDayOfMonth.map(String.init) ?? ""
+        lowMilesThresholdPercent = String(activeCar.lowMilesThresholdPercent)
+        isNotificationEnabled = activeCar.reminderDayOfMonth != nil
     }
     
     private func saveSettings() {
-        guard let startingOdometerInt = Int(startingOdometer),
+        guard let activeCar = activeCar,
+              let startingOdometerInt = Int(startingOdometer),
               let allowedMilesTotalInt = Int(allowedMilesTotal),
               let costPerMileDouble = Double(costPerMile),
               leaseEndDate > leaseStartDate else {
@@ -148,15 +176,16 @@ struct SettingsView: View {
             return
         }
         
-        settingsStore.updateSettings(
-            leaseStartDate: leaseStartDate,
-            leaseEndDate: leaseEndDate,
-            startingOdometer: startingOdometerInt,
-            allowedMilesTotal: allowedMilesTotalInt,
-            costPerMile: Decimal(costPerMileDouble),
-            reminderDayOfMonth: reminderDay,
-            lowMilesThresholdPercent: thresholdPercent
-        )
+        // Update the active car's settings
+        activeCar.leaseStartDate = leaseStartDate
+        activeCar.leaseEndDate = leaseEndDate
+        activeCar.startingOdometer = startingOdometerInt
+        activeCar.allowedMilesTotal = allowedMilesTotalInt
+        activeCar.costPerMile = Decimal(costPerMileDouble)
+        activeCar.reminderDayOfMonth = reminderDay
+        activeCar.lowMilesThresholdPercent = thresholdPercent
+        
+        carStore.updateCar(activeCar)
         
         // Update notification scheduling
         if isNotificationEnabled, let day = reminderDay {
@@ -168,8 +197,16 @@ struct SettingsView: View {
         }
     }
     
-    private func resetAllData() {
-        settingsStore.resetData()
+    private func resetCarData() {
+        guard let activeCar = activeCar else { return }
+        
+        // Delete all mileage entries for this car
+        let mileageStore = MileageStore(modelContext: modelContext)
+        let entries = mileageStore.loadEntries(for: activeCar)
+        for entry in entries {
+            mileageStore.deleteEntry(entry)
+        }
+        
         notificationManager.cancelAllReminders()
     }
 }


### PR DESCRIPTION
Add multi-car support to allow users to track multiple vehicles and their respective lease details and mileage entries.

The previous application structure only supported a single car/lease. This PR introduces a new `Car` model to encapsulate lease settings and mileage entries, along with a `CarStore` for managing multiple cars. Core views (`DashboardView`, `HistoryView`, `SettingsView`, `AddEntryView`) have been updated to operate on a currently active car, and new views (`CarSelectionView`, `AddCarView`, `EditCarView`) are added for car management. A data migration mechanism is included to seamlessly transition existing single-car data to the new multi-car structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-183606a9-aa51-4759-9215-b6c2c1f79937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-183606a9-aa51-4759-9215-b6c2c1f79937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

